### PR TITLE
イメージサイズ削減

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.6.3
 EXPOSE 80
 WORKDIR /app
-COPY . /app
+COPY ./requirements.txt /app
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
+COPY . /app
 CMD ["python","app.py"]


### PR DESCRIPTION
requirementsのライブラリが毎度キャッシュに含まれ容量食っちゃうんので、ソースコードを追加する前に依存関係を解消しておく